### PR TITLE
Add README for GoLand 2025.2 Dummy Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+## GoLand 2025.2 Dummy Plugin
+
+A minimal plugin for GoLand 2025.2 that intentionally does nothing. Useful as a template or for testing plugin installation from a local file.
+
+### Features
+- Does nothing by design
+- No settings, no UI, no background tasks
+
+### Compatibility
+- GoLand: 2025.2
+- Platforms: macOS, Windows, Linux
+
+### Installation (from local disk)
+1. Build or obtain the plugin archive (`.zip` or `.jar`).
+2. In GoLand, open:
+   - macOS: GoLand → Settings… → Plugins
+   - Windows/Linux: File → Settings… → Plugins
+3. Click the gear icon in the Plugins view and choose "Install Plugin from Disk…".
+4. Select the plugin archive and confirm.
+5. Restart GoLand when prompted.
+
+### Usage
+There is nothing to configure or run. Installation is the only action; the plugin remains inert.
+
+### Uninstall
+1. Go to Settings… → Plugins.
+2. Find the plugin in the Installed tab.
+3. Click Uninstall and restart IDE if prompted.
+
+### Privacy & Telemetry
+- No data is collected, transmitted, or stored.
+
+### License
+MIT


### PR DESCRIPTION
Added documentation for a dummy GoLand plugin, including features, compatibility, installation, usage, uninstallation, privacy, and license information.